### PR TITLE
Fix no return statement in function returning non-void

### DIFF
--- a/ESP32_HTPAd_120x84/ESP32_HTPAd_120x84.ino
+++ b/ESP32_HTPAd_120x84/ESP32_HTPAd_120x84.ino
@@ -1219,7 +1219,7 @@ void write_calibration_settings_to_sensor() {
    Description:     read eeprom register as 8
    Dependencies:    register address (address)
  *******************************************************************/
-byte write_EEPROM_byte(unsigned short address, unsigned char content ) {
+void write_EEPROM_byte(unsigned short address, unsigned char content ) {
   digitalWrite(SPI_CS, HIGH); // set HIGH, back to sensor
   delay(1);
 
@@ -1253,7 +1253,7 @@ byte write_EEPROM_byte(unsigned short address, unsigned char content ) {
    Dependencies:    register address (addr),
                     number of bytes (n)
  *******************************************************************/
-byte write_sensor_byte( unsigned char addr, unsigned char input) {
+void write_sensor_byte( unsigned char addr, unsigned char input) {
 
   digitalWrite(SPI_CS, HIGH);  // set HIGH to communicate with Sensor
   SPI.transfer(addr);  // register address eeprom

--- a/ESP32_HTPAd_16x16/ESP32_HTPAd_16x16.ino
+++ b/ESP32_HTPAd_16x16/ESP32_HTPAd_16x16.ino
@@ -1388,7 +1388,7 @@ word write_eeprom_routine(uint16_t addr, uint16_t value) {
    Dependencies:    register address (addr),
                     number of bytes (n)
  *******************************************************************/
-byte write_sensor_byte(uint8_t deviceaddress, uint8_t registeraddress, uint8_t input) {
+void write_sensor_byte(uint8_t deviceaddress, uint8_t registeraddress, uint8_t input) {
 
   Wire.beginTransmission(deviceaddress);
   Wire.write(registeraddress);

--- a/ESP32_HTPAd_32x32/ESP32_HTPAd_32x32.ino
+++ b/ESP32_HTPAd_32x32/ESP32_HTPAd_32x32.ino
@@ -1223,7 +1223,7 @@ void write_calibration_settings_to_sensor() {
    Description:     read eeprom register as 8
    Dependencies:    register address (address)
  *******************************************************************/
-byte write_EEPROM_byte(unsigned short address, unsigned char content ) {
+void write_EEPROM_byte(unsigned short address, unsigned char content ) {
 
   Wire.beginTransmission(EEPROM_ADDRESS);
   Wire.write((int)(address >> 8));   // MSB
@@ -1241,7 +1241,7 @@ byte write_EEPROM_byte(unsigned short address, unsigned char content ) {
    Dependencies:    register address (addr),
                     number of bytes (n)
  *******************************************************************/
-byte write_sensor_byte(uint8_t deviceaddress, uint8_t registeraddress, uint8_t input) {
+void write_sensor_byte(uint8_t deviceaddress, uint8_t registeraddress, uint8_t input) {
 
   Wire.beginTransmission(deviceaddress);
   Wire.write(registeraddress);

--- a/ESP32_HTPAd_60x40/ESP32_HTPAd_60x40.ino
+++ b/ESP32_HTPAd_60x40/ESP32_HTPAd_60x40.ino
@@ -1367,7 +1367,7 @@ void write_calibration_settings_to_sensor() {
    Dependencies:    register address (addr),
                     number of bytes (n)
  *******************************************************************/
-byte write_sensor_byte( unsigned char addr, unsigned char input) {
+void write_sensor_byte( unsigned char addr, unsigned char input) {
 
   digitalWrite(SPI_CS, HIGH);  // set HIGH to communicate with Sensor
   SPI.transfer(addr);  // register address eeprom

--- a/ESP32_HTPAd_84x60/ESP32_HTPAd_84x60.ino
+++ b/ESP32_HTPAd_84x60/ESP32_HTPAd_84x60.ino
@@ -1213,7 +1213,7 @@ void write_calibration_settings_to_sensor() {
    Description:     read eeprom register as 8
    Dependencies:    register address (address)
  *******************************************************************/
-byte write_EEPROM_byte(unsigned short address, unsigned char content ) {
+void write_EEPROM_byte(unsigned short address, unsigned char content ) {
   digitalWrite(SPI_CS, HIGH); // set HIGH, back to sensor
   delay(1);
 
@@ -1247,7 +1247,7 @@ byte write_EEPROM_byte(unsigned short address, unsigned char content ) {
    Dependencies:    register address (addr),
                     number of bytes (n)
  *******************************************************************/
-byte write_sensor_byte( unsigned char addr, unsigned char input) {
+void write_sensor_byte( unsigned char addr, unsigned char input) {
 
   digitalWrite(SPI_CS, HIGH);  // set HIGH to communicate with Sensor
   SPI.transfer(addr);  // register address eeprom

--- a/ESP32_HTPAd_8x8/ESP32_HTPAd_8x8.ino
+++ b/ESP32_HTPAd_8x8/ESP32_HTPAd_8x8.ino
@@ -947,7 +947,7 @@ word write_eeprom_routine(uint16_t addr, uint16_t value) {
    Dependencies:    register address (addr),
                     number of bytes (n)
  *******************************************************************/
-byte write_sensor_byte(uint8_t deviceaddress, uint8_t registeraddress, uint8_t input) {
+void write_sensor_byte(uint8_t deviceaddress, uint8_t registeraddress, uint8_t input) {
 
   Wire.beginTransmission(deviceaddress);
   Wire.write(registeraddress);


### PR DESCRIPTION
write_EEPROM_byte and write_sensor_byte don't return a value while the function descriptor tells to.

None of the callers are expecting a return value so it's safe to return void.